### PR TITLE
Support pipeline in druid compose with bind mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,12 @@ The first step is to update the appropriate `DOCKER_HOST` in `druid_setup/.env`.
     - Historical config is located in `druid_setup/cluster/environment/historical.env` (`druid_host`)
   - Also, ensure that [public key authentication](https://kb.iu.edu/d/aews) is enabled.
 
-Next, deploy the approriate Druid cluster:
+Next, create the following directories on the remote server:
+
+- /home/share
+- /data/output
+
+Finally, deploy the approriate Druid cluster:
 
 ```sh
 cd druid_setup

--- a/druid_setup/single/docker-compose.yml
+++ b/druid_setup/single/docker-compose.yml
@@ -20,13 +20,26 @@ version: "2.2"
 
 volumes:
   zen_extensions: {}
+  zookeeper_data: {}
+  zookeeper_datalog: {}
   metadata_data: {}
   middle_var: {}
   historical_var: {}
   broker_var: {}
   coordinator_var: {}
   router_var: {}
-  druid_shared: {}
+  druid_shared:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /home/share
+  data_output:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /data/output
 
 
 services:
@@ -63,15 +76,19 @@ services:
     restart: always
     ports:
       - "2181:2181"
+    volumes:
+      - zookeeper_data:/data
+      - zookeeper_datalog:/datalog
     environment:
       - ZOO_MY_ID=1
 
   coordinator:
+    platform: linux/amd64
     image: apache/druid:${DRUID_VERSION}
     container_name: coordinator
     restart: always
     volumes:
-      - druid_shared:/opt/shared
+      - druid_shared:/home/share
       - coordinator_var:/opt/druid/var
       - zen_extensions:/var/lib/zen/extensions/
     depends_on:
@@ -87,6 +104,7 @@ services:
       - environment/coordinator.env
 
   broker:
+    platform: linux/amd64
     image: apache/druid:${DRUID_VERSION}
     container_name: broker
     restart: always
@@ -108,11 +126,13 @@ services:
       - environment/broker.env
 
   historical:
+    platform: linux/amd64
     image: apache/druid:${DRUID_VERSION}
     container_name: historical
     restart: always
     volumes:
-      - druid_shared:/opt/shared
+      - druid_shared:/home/share
+      - data_output:/data/output
       - historical_var:/opt/druid/var
       - zen_extensions:/var/lib/zen/extensions/
     depends_on:
@@ -130,11 +150,13 @@ services:
       - environment/historical.env
 
   middlemanager:
+    platform: linux/amd64
     image: apache/druid:${DRUID_VERSION}
     container_name: middlemanager
     restart: always
     volumes:
-      - druid_shared:/opt/shared
+      - druid_shared:/home/share
+      - data_output:/data/output
       - middle_var:/opt/druid/var
       - zen_extensions:/var/lib/zen/extensions/
     depends_on:
@@ -152,6 +174,7 @@ services:
       - environment/middlemanager.env
 
   router:
+    platform: linux/amd64
     image: apache/druid:${DRUID_VERSION}
     container_name: router
     restart: always

--- a/druid_setup/single/environment/common.env
+++ b/druid_setup/single/environment/common.env
@@ -29,11 +29,11 @@ druid_metadata_storage_connector_password=FoolishPassword
 # use an NFS to handle the storage. This should be mapped into the druid
 # container.
 druid_storage_type=local
-druid_storage_storageDirectory=/opt/shared/segments
+druid_storage_storageDirectory=/home/share/data/druid/segments
 # Indexing logs should be stored on a directory that is mapped into the Druid
 # container so they are accessible outside the container.
 druid_indexer_logs_type=file
-druid_indexer_logs_directory=/opt/shared/indexing-logs
+druid_indexer_logs_directory=/home/share/data/logs/druid_indexing
 druid_emitter_logging_logLevel=debug
 druid_javascript_enabled=true
 

--- a/druid_setup/single/environment/middlemanager.env
+++ b/druid_setup/single/environment/middlemanager.env
@@ -1,1 +1,3 @@
+druid.indexer.task.baseTaskDir=/data/output/druid/task
+
 druid_indexer_runner_javaOptsArray=["-server", "-Xmx1g", "-Xms1g", "-XX:MaxDirectMemorySize=3g", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=100", "-XX:+PrintGCDetails", "-XX:+PrintGCTimeStamps", "-XX:+ExitOnOutOfMemoryError", "-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]


### PR DESCRIPTION
Changed the mounts to reflect the same dir structure to fit with the pipeline.
Changed  `/home/share` & `/data/output` to bind mounts - If we end up having a **dockerized** pipeline this can be changed back to just a normal named volume (similar to the other).

This also means there is an additional step to create the above directories on the host machine (README updated).
