### PR TITLE
ETL Pipeline Docker Build & Push Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ web_build:
 web_push:
 	@docker push $(DOCKER_NAMESPACE)/harmony-web:$(DOCKER_TAG)
 
-all_build: web_client_build web_server_build web_build
+etl_pipeline_build:
+	@docker build -t $(DOCKER_NAMESPACE)/harmony-etl-pipeline:$(DOCKER_TAG) \
+		-f Dockerfile_dev  .
 
-all_push: web_client_push web_server_push web_push
+etl_pipeline_push:
+	@docker push $(DOCKER_NAMESPACE)/harmony-etl-pipeline:$(DOCKER_TAG)
+
+all_build: web_client_build web_server_build web_build etl_pipeline_build
+
+all_push: web_client_push web_server_push web_push etl_pipeline_push

--- a/ci/docker/Jenkinsfile
+++ b/ci/docker/Jenkinsfile
@@ -30,5 +30,21 @@ pipeline {
                 }
             }
         }
+        // Build all docker pipeline containers
+        stage('Pipeline Build') {
+            steps {
+                sh 'make etl_pipeline_build'
+            }
+        }
+        // Push all docker pipeline containers to https://hub.docker.com/u/zengineering
+        stage('Pipeline Push') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'docker-io-credentials', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
+                    sh 'docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD'
+                    sh 'make etl_pipeline_push'
+                    sh 'docker logout'
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Build and Push the etl_pipeline docker image to the public [zengineering](https://hub.docker.com/u/zengineering) image registry.

Each merge to master will kick off the internal Jenkins pipeline.
