### PR TITLE
Remove need for git to run scripts

### DIFF
--- a/models/python/dashboard/scripts/create_new_schema.sh
+++ b/models/python/dashboard/scripts/create_new_schema.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -eu
 set -o pipefail
 
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
-
 CURRENT_VERSION=$(python -c '
 from models.python.dashboard.version import LATEST_VERSION
 print(LATEST_VERSION)
@@ -41,7 +39,7 @@ def _downgrade_${NEW_VERSION_UNDERSCORE}_specification(specification):
 echo "Current version: ${CURRENT_VERSION}"
 echo "New version: ${NEW_VERSION}"
 
-pushd "${ZEN_SRC_ROOT}/models/python/dashboard" &> /dev/null
+pushd "${ZEN_HOME}/models/python/dashboard" &> /dev/null
 
 echo '(1/10) Storing latest schema in versioned directory'
 # Check if the schema directory already exists. This should only happen if
@@ -107,7 +105,7 @@ perl \
 
 popd &> /dev/null
 
-pushd "${ZEN_SRC_ROOT}" &> /dev/null
+pushd "${ZEN_HOME}" &> /dev/null
 
 echo '(7/10) Updating EXPECTED_VERSION in the frontend DashboardSpecification.'
 
@@ -147,8 +145,8 @@ echo -e "\n${TEST_UPGRADE_DOWNGRADE}" >> models/python/dashboard/tests/test_sche
     
 echo '(9/10) Adding all new files to git'
 git add \
-  "${ZEN_SRC_ROOT}/models/python/dashboard/${SCHEMA_DIR_NAME}" \
-  "${ZEN_SRC_ROOT}/models/python/dashboard/version.py" \
+  "${ZEN_HOME}/models/python/dashboard/${SCHEMA_DIR_NAME}" \
+  "${ZEN_HOME}/models/python/dashboard/version.py" \
   models/python/dashboard/tests/test_schema_upgrade_downgrade.py \
   web/client/models/core/Dashboard/DashboardSpecification/index.js
 

--- a/pipeline/br/generate/generate_wrapper
+++ b/pipeline/br/generate/generate_wrapper
@@ -8,7 +8,6 @@ set -o pipefail
 # provided automatically.
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 # Grab the steps to run
 TASKS="${@:1}"

--- a/pipeline/br/generate/zeus_generate
+++ b/pipeline/br/generate/zeus_generate
@@ -12,13 +12,12 @@ set -o pipefail
 export ZEN_ENV='br'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" ; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='br/generate'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 
 ZEUS_CMD="\
 zeus \

--- a/pipeline/br/index/index_all
+++ b/pipeline/br/index/index_all
@@ -2,7 +2,6 @@
 set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 pushd "${SCRIPT_DIR}" &> /dev/null
 

--- a/pipeline/br/index/zeus_index
+++ b/pipeline/br/index/zeus_index
@@ -8,13 +8,12 @@ set -o pipefail
 export ZEN_ENV='br'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='br/index'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 
 ZEUS_CMD="\
 zeus \

--- a/pipeline/br/process/process_all
+++ b/pipeline/br/process/process_all
@@ -2,7 +2,6 @@
 set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 # Get the date in case the date changes before all the steps are complete.
 DATE=$(date +%Y%m%d)

--- a/pipeline/br/process/zeus_process
+++ b/pipeline/br/process/zeus_process
@@ -9,13 +9,12 @@ set -o pipefail
 export ZEN_ENV='br'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='br/process'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 ZEUS_PUBLISH_DIR="/home/share/data/br"
 
 ZEUS_CMD="\

--- a/pipeline/br/validate/validate_all
+++ b/pipeline/br/validate/validate_all
@@ -2,7 +2,6 @@
 set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 # Get the date in case the date changes before all the steps are complete.
 DATE=$(date +%Y%m%d)

--- a/pipeline/br/validate/zeus_validate
+++ b/pipeline/br/validate/zeus_validate
@@ -10,13 +10,12 @@ set -o pipefail
 export ZEN_ENV='br'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='br/validate'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 ZEUS_PUBLISH_DIR="/home/share/data/br/validate"
 
 ZEUS_CMD="\

--- a/pipeline/template/generate/generate_wrapper
+++ b/pipeline/template/generate/generate_wrapper
@@ -8,7 +8,6 @@ set -o pipefail
 # provided automatically.
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 # Grab the steps to run
 TASKS="${@:1}"

--- a/pipeline/template/generate/zeus_generate
+++ b/pipeline/template/generate/zeus_generate
@@ -12,13 +12,12 @@ set -o pipefail
 export ZEN_ENV='SITECODE'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" ; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='SAMPLE/generate'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 
 ZEUS_CMD="\
 zeus \

--- a/pipeline/template/index/index_all
+++ b/pipeline/template/index/index_all
@@ -2,7 +2,6 @@
 set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 pushd "${SCRIPT_DIR}" &> /dev/null
 

--- a/pipeline/template/index/zeus_index
+++ b/pipeline/template/index/zeus_index
@@ -8,13 +8,12 @@ set -o pipefail
 export ZEN_ENV='SITECODE'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='SAMPLE/index'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 
 ZEUS_CMD="\
 zeus \

--- a/pipeline/template/process/process_all
+++ b/pipeline/template/process/process_all
@@ -2,7 +2,6 @@
 set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 # Get the date in case the date changes before all the steps are complete.
 DATE=$(date +%Y%m%d)

--- a/pipeline/template/process/zeus_process
+++ b/pipeline/template/process/zeus_process
@@ -9,13 +9,12 @@ set -o pipefail
 export ZEN_ENV='SITECODE'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='SAMPLE/process'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 ZEUS_PUBLISH_DIR="/home/share/data/SAMPLE"
 
 ZEUS_CMD="\

--- a/pipeline/template/validate/validate_all
+++ b/pipeline/template/validate/validate_all
@@ -2,7 +2,6 @@
 set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 # Get the date in case the date changes before all the steps are complete.
 DATE=$(date +%Y%m%d)

--- a/pipeline/template/validate/zeus_validate
+++ b/pipeline/template/validate/zeus_validate
@@ -10,13 +10,12 @@ set -o pipefail
 export ZEN_ENV='SITECODE'
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 ZEUS_ID='SAMPLE/validate'
 ZEUS_OUT_DIRS='feed,out,tmp'
 ZEUS_ROOT_DIR="${SCRIPT_DIR}/run"
 ZEUS_BIN_DIR="${SCRIPT_DIR}/../bin"
-ZEUS_UTILS_DIR="${ZEN_SRC_ROOT}/util/pipeline"
+ZEUS_UTILS_DIR="${ZEN_HOME}/util/pipeline"
 ZEUS_PUBLISH_DIR="/home/share/data/SAMPLE/validate"
 
 ZEUS_CMD="\

--- a/scripts/create_deployment_config.sh
+++ b/scripts/create_deployment_config.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
 set -o pipefail
 
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 if [ $# -ne 2 ] ; then
   echo 'Usage: ./create_deployment_config.sh DEPLOYMENT_CODE PRETTY_NAME'
@@ -15,7 +14,7 @@ fi
 
 DEPLOYMENT_CODE="$1"
 PRETTY_NAME="$2"
-CONFIG_DIR="${ZEN_SRC_ROOT}/config/${DEPLOYMENT_CODE}"
+CONFIG_DIR="${ZEN_HOME}/config/${DEPLOYMENT_CODE}"
 
 echo "Deployment code: ${DEPLOYMENT_CODE}"
 echo "Pretty deployment name: ${PRETTY_NAME}"
@@ -26,7 +25,7 @@ if [ -d "${CONFIG_DIR}" ] ; then
   exit 1
 fi
 
-pushd "${ZEN_SRC_ROOT}" &> /dev/null
+pushd "${ZEN_HOME}" &> /dev/null
 
 echo "Copying config template to ${CONFIG_DIR}"
 cp -r config/template "${CONFIG_DIR}"

--- a/scripts/create_deployment_pipeline.sh
+++ b/scripts/create_deployment_pipeline.sh
@@ -15,7 +15,6 @@ fi
 # config.general. Update this script to match that naming convention.
 DEPLOYMENT_NAME="$1"
 DEPLOYMENT_CODE="$2"
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 DEPLOYMENT_NAME_PATTERN='^[a-z_]+$'
 
 echo "Building deployment pipeline with name: ${DEPLOYMENT_NAME} \
@@ -26,17 +25,17 @@ if ! [[ "${DEPLOYMENT_NAME}" =~ ${DEPLOYMENT_NAME_PATTERN} ]] ; then
   exit 1
 fi
 
-if ! [ -d "${ZEN_SRC_ROOT}/config/${DEPLOYMENT_CODE}" ] ; then
+if ! [ -d "${ZEN_HOME}/config/${DEPLOYMENT_CODE}" ] ; then
   echo 'Config must be defined before a deployment pipeline can be created'
   exit 1
 fi
 
-if [ -d "${ZEN_SRC_ROOT}/pipeline/${DEPLOYMENT_NAME}" ] ; then
+if [ -d "${ZEN_HOME}/pipeline/${DEPLOYMENT_NAME}" ] ; then
   echo "Pipeline for deployment '${DEPLOYMENT_NAME}' already exists. Quitting"
   exit 1
 fi
 
-pushd "${ZEN_SRC_ROOT}/pipeline" &> /dev/null
+pushd "${ZEN_HOME}/pipeline" &> /dev/null
 
 # Copy the template pipeline as the base pipeline for this new deployment
 cp -r template "${DEPLOYMENT_NAME}"

--- a/scripts/db/hasura/dev/create_metadata_snapshot.sh
+++ b/scripts/db/hasura/dev/create_metadata_snapshot.sh
@@ -2,8 +2,7 @@
 set -o pipefail
 
 CONTAINER_NAME='hasura'
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
-HASURA_METADATA_DIR="${ZEN_SRC_ROOT}/graphql/hasura/metadata/versions"
+HASURA_METADATA_DIR="${ZEN_HOME}/graphql/hasura/metadata/versions"
 
 pushd "${HASURA_METADATA_DIR}" &> /dev/null
 

--- a/scripts/db/hasura/dev/start_hasura.sh
+++ b/scripts/db/hasura/dev/start_hasura.sh
@@ -3,9 +3,8 @@ set -o pipefail
 
 DB_NAME="$1"
 CONTAINER_NAME='hasura'
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
-HASURA_METADATA_DIR="${ZEN_SRC_ROOT}/graphql/hasura/metadata/versions"
-HASURA_CONTAINER_SCRIPTS_DIR="${ZEN_SRC_ROOT}/scripts/db/hasura/dev/container"
+HASURA_METADATA_DIR="${ZEN_HOME}/graphql/hasura/metadata/versions"
+HASURA_CONTAINER_SCRIPTS_DIR="${ZEN_HOME}/scripts/db/hasura/dev/container"
 
 # Check to see if hasura is running.
 CONTAINER_COUNT=$(docker ps -q --filter "name=^${CONTAINER_NAME}\$" | wc -l)

--- a/scripts/db/hasura/dev/sync_graphql_schema.sh
+++ b/scripts/db/hasura/dev/sync_graphql_schema.sh
@@ -1,9 +1,7 @@
 #!/bin/bash -eu
 set -o pipefail
 
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
-
-pushd "${ZEN_SRC_ROOT}" &> /dev/null
+pushd "${ZEN_HOME}" &> /dev/null
 
 DESTINATION='graphql/schema.graphql'
 

--- a/scripts/db/postgres/dev/downgrade_dev_database.sh
+++ b/scripts/db/postgres/dev/downgrade_dev_database.sh
@@ -3,9 +3,8 @@ set -o pipefail
 
 DEPLOYMENT_CODE="$1"
 DB_NAME="$2"
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
-pushd "${ZEN_SRC_ROOT}" &> /dev/null
+pushd "${ZEN_HOME}" &> /dev/null
 
 # Run the Flask-Migrate command to downgrade the database tables to the latest
 # version.

--- a/scripts/db/postgres/dev/upgrade_dev_database.sh
+++ b/scripts/db/postgres/dev/upgrade_dev_database.sh
@@ -5,7 +5,6 @@ DEPLOYMENT_CODE="$1"
 DB_NAME="$2"
 SCRIPT_DIR=$(cd "$(dirname "$0")" ; pwd -P)
 POSTGRES_SYSTEM_USER="postgres"
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
 
 
 # Test to see if the destination database already exists.
@@ -16,7 +15,7 @@ if [[ "${DB_EXISTS_TEST}" == '' ]] ; then
   psql -h ${DATABASE_HOST:-postgres} -U postgres postgres -tAc "CREATE DATABASE \"${DB_NAME}\""
 fi
 
-pushd "${ZEN_SRC_ROOT}" &> /dev/null
+pushd "${ZEN_HOME}" &> /dev/null
 
 # Run the Flask-Migrate command to upgrade the database tables to the latest
 # version.

--- a/scripts/generate_migration_script.sh
+++ b/scripts/generate_migration_script.sh
@@ -15,9 +15,7 @@ if [ -z "${ZEN_ENV:-}" ] ; then
   exit 1
 fi
 
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
-
-pushd "${ZEN_SRC_ROOT}" &> /dev/null
+pushd "${ZEN_HOME}" &> /dev/null
 
 # NOTE(stephen): If someone didn't use `init-db` to run this script, we
 # hardcode the local DB name to use (building migrations can only ever be run in

--- a/scripts/upgrade_database.sh
+++ b/scripts/upgrade_database.sh
@@ -13,9 +13,7 @@ if [ -z "${ZEN_ENV:-}" ] ; then
   exit 1
 fi
 
-ZEN_SRC_ROOT=$(git rev-parse --show-toplevel)
-
-pushd "${ZEN_SRC_ROOT}" &> /dev/null
+pushd "${ZEN_HOME}" &> /dev/null
 
 FLASK_APP='web.server.app' ZEN_OFFLINE='1' flask db upgrade
 


### PR DESCRIPTION
We do not have git in our docker images - so have to use environment variable to find home folder.

ZEN_HOME has to now be specified, and point to base folder.