### PR TITLE
new random password script

### DIFF
--- a/scripts/create_deployment_database.sh
+++ b/scripts/create_deployment_database.sh
@@ -28,7 +28,7 @@ else
   echo "Logging only enabled..."
 fi
 
-DB_ADMIN_PASSWORD=$(openssl rand -base64 32)
+DB_ADMIN_PASSWORD=$(cat /dev/urandom | tr -dc 'A-Za-z0-9!' | head -c 13 ; echo ` `)
 
 SQL_CREATE_USER="$(cat <<-EOM
 


### PR DESCRIPTION
previous algorithm was generating characters that confuses hasura

e.g. `"postgresql://harmony-admin:HiekyClDY7M+ew/+qckLLMk+BMPi3o2bBjIR1RaRhfE=@postgres.harmony_network:5432/harmony"`
results in `{"code":"postgres-error","error":"connection error","internal":"invalid integer value \"HiekyClDY7M+ew\" for connection option \"port\"\n","path":"$"}`
