### PR TITLE
automatic pruning is problematic when doing local builds

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -14,11 +14,9 @@ prune:
 
 up:
 	@DOCKER_HOST=$(DOCKER_HOST) docker compose --project-name ${PROJECT_NAME} --env-file $(ENV_FILE) --file docker-compose.yml up -d --force-recreate
-	@DOCKER_HOST=$(DOCKER_HOST) docker system prune --all --force --filter "until=24h"
 
 down:
 	@DOCKER_HOST=$(DOCKER_HOST) docker compose --project-name ${PROJECT_NAME} --env-file $(ENV_FILE) --file docker-compose.yml down
-	@DOCKER_HOST=$(DOCKER_HOST) docker system prune --all --force --filter "until=24h"
 
 logs:
 	@DOCKER_HOST=$(DOCKER_HOST) docker compose --project-name ${PROJECT_NAME} --env-file $(ENV_FILE) --file docker-compose.yml logs -f


### PR DESCRIPTION
Waiting an hour for a local build, only to have prune delete it. Nope. Prune must be explicit, not automatic.