### PR TITLE
adding a default prompt can help confusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 DOCKER_NAMESPACE=zengineering
 DOCKER_TAG=latest
 
+default:
+	@echo "Please specify a target to make"
+
 web_client_build:
 	@docker build -t $(DOCKER_NAMESPACE)/harmony-web-client:$(DOCKER_TAG) \
 		-f docker/web/Dockerfile_web-client .

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -4,6 +4,9 @@ include $(ENV_FILE)
 DOCKER_HOST ?= ssh://$(ZEN_WEB_REMOTE)
 PROJECT_NAME ?= harmony-web
 
+default:
+	@echo "Please specify a target to make"
+
 configure:
 	@scp nginx/nginx_vhost_default_location $(ZEN_WEB_REMOTE):${NGINX_DEFAULT_VHOST_CONFIG}
 	@scp instance_config.json $(ZEN_WEB_REMOTE):${INSTANCE_CONFIG}

--- a/druid_setup/Makefile
+++ b/druid_setup/Makefile
@@ -5,6 +5,9 @@ PROJECT_NAME=harmony-druid
 
 include $(ENV_FILE)
 
+default:
+	@echo "Please specify a target to make"
+
 single_server_up:
 	@cd single && \
 		DOCKER_HOST=$(SINGLE_SERVER_DOCKER_HOST) \


### PR DESCRIPTION
I've observed developers not familiar with the platform running `make` with no parameters - and then being confused about what's happening.
Altogether a better experience to guide them to be explicit.