### PR TITLE
Rename druid project

### DIFF
--- a/druid_setup/Makefile
+++ b/druid_setup/Makefile
@@ -1,7 +1,7 @@
 ENV_FILE=.env
 ENV_COMMON=environment/common.env
 
-PROJECT_NAME=harmony-druid
+PROJECT_NAME=druid
 
 include $(ENV_FILE)
 


### PR DESCRIPTION
Calling the project harmony-druid can get very confusing. The postgres database service contains the wording harmony, which can easily be confused with the harmony postgres service.

Doing a quick `docker ps` one can easily get confused by the two.