### PR TITLE
newer version of node causing issue

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.17]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
+        id: setup-node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
@@ -126,7 +127,7 @@ jobs:
         id: cache-node_modules
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
       - name: Install dependencies
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: |

--- a/docker/web/Dockerfile_web-client
+++ b/docker/web/Dockerfile_web-client
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.17
 
 # Separate directories for storing build files so that the post-build results
 # can be easily copied out.


### PR DESCRIPTION
Recent release of node 18.18: https://nodejs.org/en/blog/release/v18.18.0 causes our builds to fail.

- locked to 18.17
- update node cache to use exact version

**Test Plan:**
Check that it builds.

