### PR TITLE
Fix translations

### DIFF
--- a/web/client/components/AdminApp/ConfigurationTab/SelfServeControlBlock/i18n.js
+++ b/web/client/components/AdminApp/ConfigurationTab/SelfServeControlBlock/i18n.js
@@ -265,9 +265,9 @@ const translations: TranslationDictionary = {
     importSelfServe: 'Configura\xE7\xE3o de importa\xE7\xE3o autom\xE1tica',
     importSetupPrompt:
       'A importa\xE7\xE3o desta nova configura\xE7\xE3o de auto-atendimento sobregravar\xE1 o cat\xE1logo de dados atualmente ativo e as fontes de carregamento de dados. Ao fazer isso, observe que voc\xEA pode sobrescrever as mudan\xE7as n\xE3o inclu\xEDdas na configura\xE7\xE3o importada. Ap\xF3s completar esta a\xE7\xE3o, se surgir um problema com a nova configura\xE7\xE3o de autoatendimento, voc\xEA poder\xE1 reimportar a configura\xE7\xE3o atual de autoatendimento (encontrada em sua pasta Downloads).',
-    '%(fileName)s Passes Validation': '%(fileName)s passa na valida\\xE7\\xE3o',
+    '%(fileName)s Passes Validation': '%(fileName)s passa na valida\xE7\xE3o',
     '%(fileName)s contains potential conflicts':
-      '%(fileName)s cont\\xE9m poss\\xEDveis conflitos',
+      '%(fileName)s cont\xE9m poss\xEDveis conflitos',
     'Are you sure you want to import %(csvFileName)s?':
       'Voc\xEA tem certeza de que quer importar %(csvFileName)s?',
     'Are you sure you want to import %(fileName)s?':
@@ -282,7 +282,7 @@ const translations: TranslationDictionary = {
     'Import a self serve setup to replace the active one on this instance':
       'Importar uma configura\xE7\xE3o de auto-atendimento para substituir a ativa neste caso',
     'Import a self serve setup to replace the active one on this instance_ You can export this setup in the Admin App in the Site Configuration tab_ This setup will replace the existing metadata in this instance for the following records: Field, Field Category, Dimension, Dimension Category, and Datasource_':
-      'Importe uma configura\\xE7\\xE3o de autoatendimento para substituir a configura\\xE7\\xE3o ativa nessa inst\\xE2ncia. Voc\\xEA pode exportar essa configura\\xE7\\xE3o no aplicativo Admin, na guia Site Configuration (Configura\\xE7\\xE3o do site). Essa configura\\xE7\\xE3o substituir\\xE1 os metadados existentes nessa inst\\xE2ncia para os seguintes registros: Field (Campo), Field Category (Categoria de campo), Dimension (Dimens\\xE3o), Dimension Category (Categoria de dimens\\xE3o) e Datasource (Fonte de dados).',
+      'Importe uma configura\xE7\xE3o de autoatendimento para substituir a configura\xE7\xE3o ativa nessa inst\xE2ncia. Voc\xEA pode exportar essa configura\xE7\xE3o no aplicativo Admin, na guia Site Configuration (Configura\xE7\xE3o do site). Essa configura\xE7\xE3o substituir\xE1 os metadados existentes nessa inst\xE2ncia para os seguintes registros: Field (Campo), Field Category (Categoria de campo), Dimension (Dimens\xE3o), Dimension Category (Categoria de dimens\xE3o) e Datasource (Fonte de dados).',
     'Import confirmation': 'Confirma\xE7\xE3o de importa\xE7\xE3o',
     'Import new indicators or update existing indicators defined in the Google Sheet CSV':
       'Importar novos indicadores ou atualizar indicadores existentes definidos no Google Sheet CSV',
@@ -290,7 +290,7 @@ const translations: TranslationDictionary = {
     'Select file to import': 'Selecione o arquivo a ser importado',
     'Self Serve': 'Auto-servi\xE7o',
     'Your data catalog conflicts summary file will download shortly':
-      'Seu arquivo de resumo de conflitos do cat\\xE1logo de dados ser\\xE1 baixado em breve',
+      'Seu arquivo de resumo de conflitos do cat\xE1logo de dados ser\xE1 baixado em breve',
     'Your data catalog metadata export will download shortly':
       'Sua exporta\xE7\xE3o de metadados do cat\xE1logo de dados ser\xE1 baixada em breve',
     'Your fields csv import might take some time to complete':

--- a/web/client/components/Authentication/i18n.js
+++ b/web/client/components/Authentication/i18n.js
@@ -100,7 +100,7 @@ const translations: TranslationDictionary = {
     invalid_login_credentials: 'Nome de usu\xE1rio e/ou senha incorretos.',
     invalid_reset_link: 'Link de redefini\xE7\xE3o de senha inv\xE1lido.',
     no_invitation_link: 'O registro \xE9 somente por convite.',
-    non_existent_user: 'Esta conta de usu\\xE1rio n\\xE3o existe',
+    non_existent_user: 'Esta conta de usu\xE1rio n\xE3o existe',
     password_reset_email_failed:
       'Falha no envio do e-mail de redefini\xE7\xE3o de senha.',
     password_reset_email_sent:

--- a/web/client/components/DataQualityApp/i18n.js
+++ b/web/client/components/DataQualityApp/i18n.js
@@ -24,6 +24,7 @@ const translations: TranslationDictionary = {
     Categorical: 'Categorical',
     high: 'high',
     low: 'low',
+    medium: 'medium',
     'Add Filter': 'Add Filter',
     'Select indicator': 'Select indicator',
     'The Quality Score is based on the following factors___':
@@ -35,6 +36,7 @@ const translations: TranslationDictionary = {
     Categorical: 'Categ\xF3rico',
     high: 'alto',
     low: 'baixo',
+    medium: 'm\xE9dio',
     'Add Filter': 'Adicionar filtro',
     'Select indicator': 'Selecione o indicador',
     'The Quality Score is based on the following factors___':
@@ -46,6 +48,7 @@ const translations: TranslationDictionary = {
     Categorical: 'Ph\xE2n lo\u1EA1i',
     high: 'cao',
     low: 'Th\u1EA5p',
+    medium: 'v\u1EEBa ph\u1EA3i',
     'Add Filter': 'Th\xEAm b\u1ED9 l\u1ECDc',
     'Select indicator': 'Ch\u1ECDn ch\u1EC9 s\u1ED1',
     'The Quality Score is based on the following factors___':
@@ -57,6 +60,7 @@ const translations: TranslationDictionary = {
     Categorical: 'ምድብ',
     high: 'ከፍተኛ',
     low: 'ዝቅተኛ',
+    medium: 'መካከለኛ',
     'Add Filter': '\u121B\u1323\u122A\u12EB \u12EB\u12AD\u1209',
     'Select indicator':
       '\u12A0\u1218\u120D\u12AB\u127D \u12ED\u121D\u1228\u1321',
@@ -69,6 +73,7 @@ const translations: TranslationDictionary = {
     Categorical: 'Cat\xE9gorique',
     high: 'élevé',
     low: 'faible',
+    medium: 'moyen',
     'Add Filter': 'Ajouter un filtre',
     'Select indicator': "S\xE9lectionner l'indicateur",
     'The Quality Score is based on the following factors___':
@@ -80,6 +85,7 @@ const translations: TranslationDictionary = {
     Categorical: 'Categ\xF3rico',
     high: 'alto',
     low: 'baixo',
+    medium: 'm\xE9dio',
     'Add Filter': 'Adicionar filtro',
     'Select indicator': 'Selecione o indicador',
     'The Quality Score is based on the following factors___':

--- a/web/client/components/common/i18n.js
+++ b/web/client/components/common/i18n.js
@@ -127,7 +127,7 @@ const translations: TranslationDictionary = {
     instructionFormat:
       "Para essa ação, por favor digite '%(acknowledgeText)s' para confirmar que entendeu.",
     'After clicking `Complete Upload`, the new setup will be applied_':
-      'Ap\\xF3s clicar em `Complete Upload`, a nova configura\\xE7\\xE3o ser\\xE1 aplicada.',
+      'Ap\xF3s clicar em `Complete Upload`, a nova configura\xE7\xE3o ser\xE1 aplicada.',
     'Are you sure you want to delete this entry?':
       'Tem a certeza de que pretende apagar esta entrada?',
     'Before continuing with this import, we highly recommend that you review the conflicts_ You can review these conflicts by downloading a summary below_ If there are conflitcs that should not be overwritten (e_g_ new calculated indicators), we recommend that you recreate these first before overwriting the active setup_':
@@ -136,7 +136,7 @@ const translations: TranslationDictionary = {
       'Não pode criar um painel com nome em branco',
     'Confirmation Required': 'Confirmação necessária',
     'Create Dashboard': 'Criar Painel',
-    'Download Conflict Report': 'Download do relat\\xF3rio de conflitos',
+    'Download Conflict Report': 'Download do relat\xF3rio de conflitos',
     'I understand': 'Eu entendo',
     'What would you like to name your new dashboard?':
       'Qual nome queres dar ao seu novo paínel?',

--- a/web/client/components/visualizations/common/SettingsModal/SeriesSettingsTab/i18n.js
+++ b/web/client/components/visualizations/common/SettingsModal/SeriesSettingsTab/i18n.js
@@ -237,7 +237,7 @@ const translations: TranslationDictionary = {
     'Abbreviated (K/M/B) (3 decimals)': 'Abreviado (K/M/B) (3 decimais)',
     'Hide series': 'Ocultar s\xE9ries',
     'Note: Settings applied when bar chart is unpivoted are applied to all series':
-      'Observa\\xE7\\xE3o: as configura\\xE7\\xF5es aplicadas quando o gr\\xE1fico de barras \\xE9 desvinculado s\\xE3o aplicadas a todas as s\\xE9ries',
+      'Observa\xE7\xE3o: as configura\xE7\xF5es aplicadas quando o gr\xE1fico de barras \xE9 desvinculado s\xE3o aplicadas a todas as s\xE9ries',
     'Percentage (0 decimals)': 'Porcentagem (0 decimais)',
     'Percentage (1 decimals)': 'Porcentagem (1 decimal)',
     'Percentage (2 decimals)': 'Porcentagem (2 decimais)',


### PR DESCRIPTION
**Summary:**
Some br portuguese translations were copied over correctly and had "//x" instead of "/x". Fix those. 

The translations for "medium" were also missing so add those.

**Test Plan:**
Ran local server and checked translations are now correctly appearing in the UI.
<img width="833" alt="Screenshot 2023-10-03 at 11 23 01 AM" src="https://github.com/Zenysis/Harmony/assets/13679187/07132b9e-e942-4df6-9ca6-15d15ab3a199">

Running `make bash-web` and `yarn cli-translations generate` leaves the translations files unchanged meaning all translations are up to date. 
