### PR TITLE
Celery needs to be upgraded to work with latest pip ; PRO-961

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ junit-xml>=1.9
 deepdiff==5.5.0
 ordered-set==4.0.2
 pytest-asyncio==0.20.3
-pytest-httpx==0.20.0
+pytest-httpx==0.30.0
 # Other dev deps
 pip-licenses==1.7.1
 termcolor==1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,8 @@ PyNaCl==1.4.0
 paramiko==2.7.1
 
 # Testing
-pytest>=6.2.5
-pytest-selenium==4.0.0
+pytest>=7.4.3
+pytest-selenium==4.0.1
 selenium==4.5.0
 pytest-flask>=0.15.0
 pytest-xdist>=1.29.0

--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -7,7 +7,7 @@ flask-caching==2.0.1
 flask-login==0.4.1
 gunicorn[gevent]==20.0.4
 isodate>=0.5.4
-redis==3.2.1
+redis==5.0.1
 scipy>=1.2.1
 twilio==6.24.1
 PyJWT==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
 # It's still to be examined if all of these are really necessary there.
-celery==4.4.6
+celery==5.4.0
 Werkzeug==0.16.1
 MarkupSafe==0.23
 Flask==1.0.1
@@ -26,7 +26,7 @@ psycopg2-binary==2.8.5 ; platform_python_implementation != 'PyPy' # use psycopg2
 python-Levenshtein==0.12.0
 python-dateutil>=2.8.1
 requests==2.28.1 ; platform_python_implementation != 'PyPy'
-httpx==0.22.0
+httpx[socks]==0.27.0
 six>=1.9.0
 stringcase==1.2.0
 toposort==1.5
@@ -80,3 +80,4 @@ openpyxl>=3.0.9
 ijson-bigint==3.2.0.post1
 
 types-jsonschema==4.17.0.8
+future==0.18.3

--- a/web/server/configuration/celery.py
+++ b/web/server/configuration/celery.py
@@ -1,24 +1,24 @@
 # Celery configurations
 from os import getenv
 
-DEFAULT_BROKER_URL = 'redis://redis:6379'
+DEFAULT_BROKER_URL = 'redis://redis:6379/'
 
 
 def get_broker_url():
     redis_host = getenv('REDIS_HOST')
     if redis_host:
-        broker_url = f'redis://{redis_host}:6379'
+        broker_url = f'redis://{redis_host}:6379/'
         return broker_url
     return getenv('BROKER_URL', DEFAULT_BROKER_URL)
 
 
 class CeleryConfig:
-    CELERY_RESULT_BACKEND = get_broker_url()
-    BROKER_URL = get_broker_url()
-    CELERY_ACCEPT_CONTENT = ['application/json']
-    CELERY_TASK_SERIALIZER = 'json'
-    CELERY_RESULT_SERIALIZER = 'json'
+    result_backend = get_broker_url()
+    broker_url = get_broker_url()
+    accept_content = ['application/json']
+    task_serializer = 'json'
+    result_serializer = 'json'
     MAILGUN_URL = 'https://api.mailgun.net/v3/{0}/messages'
     TASKS_LIST = ['web.server.tasks.notifications']
     CELERY_ENABLE_UTC = True
-    CELERY_TRACK_STARTED = True
+    task_track_started = True

--- a/web/server/tasks/notifications.py
+++ b/web/server/tasks/notifications.py
@@ -1,12 +1,13 @@
-from celery.task.base import Task
 import related
 from log import LOG
 from web.server.errors.errors import NotificationError
 from web.server.notifications.sms_client import TwilioClient
 from web.server.util.email_client import EmailMessage, EmailClient
+from web.server.workers import celery_app
 
 
-class SendEmailTask(Task):
+@celery_app.register_task
+class SendEmailTask(celery_app.Task): # type: ignore[name-defined]
     name = 'send_email_task'
     ignore_result = True
 
@@ -18,7 +19,8 @@ class SendEmailTask(Task):
         EmailClient(**email_client_kwargs).send(mail_msg=msg)
 
 
-class SendSMSTask(Task):
+@celery_app.register_task
+class SendSMSTask(celery_app.Task): # type: ignore[name-defined]
     name = 'send_sms_task'
     ignore_result = True
 

--- a/web/server/tasks/notifications.py
+++ b/web/server/tasks/notifications.py
@@ -7,7 +7,7 @@ from web.server.workers import celery_app
 
 
 @celery_app.register_task
-class SendEmailTask(celery_app.Task): # type: ignore[name-defined]
+class SendEmailTask(celery_app.Task):  # type: ignore[name-defined]
     name = 'send_email_task'
     ignore_result = True
 
@@ -20,7 +20,7 @@ class SendEmailTask(celery_app.Task): # type: ignore[name-defined]
 
 
 @celery_app.register_task
-class SendSMSTask(celery_app.Task): # type: ignore[name-defined]
+class SendSMSTask(celery_app.Task):  # type: ignore[name-defined]
     name = 'send_sms_task'
     ignore_result = True
 

--- a/web/server/workers/__init__.py
+++ b/web/server/workers/__init__.py
@@ -27,6 +27,9 @@ def init(**_kwargs):
             initialize_cache(app)
             initialize_jwt_manager(app)
 
+config = CeleryConfig()
+celery_app = Celery(__name__, include=config.TASKS_LIST)
+celery_app.config_from_object(config)
 
 def create_celery(instance_configuration=None):
     '''Create a new celery application instance'''
@@ -45,7 +48,5 @@ def create_celery(instance_configuration=None):
         max_overflow=0,
         connect_args={'application_name': 'worker'},
     )
-    celery = Celery(__name__, include=config.TASKS_LIST)
-    celery.config_from_object(config)
-    celery.conf['engine'] = engine
-    return celery
+    celery_app.conf['engine'] = engine
+    return celery_app

--- a/web/server/workers/__init__.py
+++ b/web/server/workers/__init__.py
@@ -27,9 +27,11 @@ def init(**_kwargs):
             initialize_cache(app)
             initialize_jwt_manager(app)
 
+
 config = CeleryConfig()
 celery_app = Celery(__name__, include=config.TASKS_LIST)
 celery_app.config_from_object(config)
+
 
 def create_celery(instance_configuration=None):
     '''Create a new celery application instance'''


### PR DESCRIPTION
**Summary:**
Celery no longer works with the latest version of pip, and needs to be upgraded.

**Test Plan:**
No practical test at this point without a a decent testing environment.
