### PR TITLE
Setuptools module error

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,10 +37,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m venv venv
           source venv/bin/activate
-          pip install -r requirements.txt
-          pip install -r requirements-web.txt
-          pip install -r requirements-dev.txt
-          pip install -r requirements-pipeline.txt
+          pip install wheel==0.43.0
+          pip install --no-build-isolation --verbose -r requirements.txt -r requirements-web.txt -r requirements-dev.txt -r requirements-pipeline.txt
       - name: Cache dependencies
         uses: actions/cache/save@v3
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -135,12 +135,13 @@ USER zenysis
 #       work.
 RUN python3.9 -m pip install --upgrade pip \
     && python3.9 -m venv venv \
-    && . venv/bin/activate && python -m pip install --upgrade pip
+    && . venv/bin/activate \
+    && python -m pip install --upgrade pip \
+    && python -m pip install "setuptools==71.1.0"
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
-    && python -m pip install -r requirements.txt \
-    && python -m pip install -r requirements-pipeline.txt
+    && python -m pip install -r requirements.txt -r requirements-pipeline.txt
 
 # PyPy
 # Update setup and create venv.
@@ -154,9 +155,9 @@ RUN pypy3 -m pip install --upgrade pip setuptools \
     && pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
 RUN . venv_pypy3/bin/activate \
-    && pypy3 -m pip install --upgrade pip setuptools \
-    && pypy3 -m pip install -r requirements.txt \
-    && pypy3 -m pip install -r requirements-pipeline.txt
+    && pypy3 -m pip install --upgrade pip \
+    && pypy3 -m pip install "setuptools==71.1.0" \
+    && pypy3 -m pip install -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.
 COPY pipeline ./pipeline

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -149,8 +149,9 @@ RUN . venv/bin/activate \
 #       image.
 RUN pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
+# pip-24.2
 RUN . venv_pypy3/bin/activate \
-    && pypy3 -m pip install --no-build-isolation -r requirements.txt -r requirements-pipeline.txt
+    && pypy -m pip install --no-build-isolation -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.
 COPY pipeline ./pipeline

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -136,8 +136,7 @@ USER zenysis
 RUN python3.9 -m pip install --upgrade pip \
     && python3.9 -m venv venv \
     && . venv/bin/activate \
-    && python -m pip install --upgrade pip \
-    && python -m pip install "setuptools==71.1.0"
+    && python -m pip install --upgrade pip
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
@@ -156,7 +155,6 @@ RUN pypy3 -m pip install --upgrade pip setuptools \
 # Install pypy dependencies.
 RUN . venv_pypy3/bin/activate \
     && pypy3 -m pip install --upgrade pip \
-    && pypy3 -m pip install "setuptools==71.1.0" \
     && pypy3 -m pip install -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -139,7 +139,8 @@ RUN python3.9 -m venv venv \
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
-    && python -m pip install --no-build-isolation -r requirements.txt -r requirements-pipeline.txt
+    && python -m pip install --upgrade pip \
+    && python -m pip install --no-build-isolation --verbose -r requirements.txt -r requirements-pipeline.txt
 
 # PyPy
 # Update setup and create venv.

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -133,16 +133,13 @@ USER zenysis
 # NOTE: We can't easily create a venv in a seperate Docker stage, and then
 #       copy it here. Various links will be broken, and the venv will not
 #       work.
-RUN python3.9 -m pip install pip=="24.1" \
-    && python3.9 -m venv venv \
+RUN python3.9 -m venv venv \
     && . venv/bin/activate \
-    && python -m pip install pip=="24.1"
+    && python -m pip install --upgrade pip setuptools
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
-    && python -m pip install -r requirements.txt
-RUN . venv/bin/activate \
-    && python -m pip install -r requirements-pipeline.txt
+    && python -m pip install -r requirements.txt -r requirements-pipeline.txt
 
 # PyPy
 # Update setup and create venv.
@@ -152,11 +149,10 @@ RUN . venv/bin/activate \
 # TODO: Investigate what it would take to have venv happen in a different
 #       build stage and copy it here. It would result in a leaner, cleaner
 #       image.
-RUN pypy3 -m pip install pip=="24.1" \
-    && pypy3 -m venv venv_pypy3
+RUN pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
 RUN . venv_pypy3/bin/activate \
-    && pypy3 -m pip install pip=="24.1" \
+    && pypy3 -m pip install --upgrade pip setuptools \
     && pypy3 -m pip install -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -133,12 +133,9 @@ USER zenysis
 # NOTE: We can't easily create a venv in a seperate Docker stage, and then
 #       copy it here. Various links will be broken, and the venv will not
 #       work.
-RUN python3.9 -m venv venv \
-    && . venv/bin/activate \
-    && python -m pip install --upgrade pip
+RUN python3.9 -m venv venv
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
-# && python -m pip install --upgrade pip \
 RUN . venv/bin/activate \
     && python -m pip install --no-build-isolation --verbose -r requirements.txt -r requirements-pipeline.txt
 
@@ -153,7 +150,6 @@ RUN . venv/bin/activate \
 RUN pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
 RUN . venv_pypy3/bin/activate \
-    && pypy3 -m pip install --upgrade pip \
     && pypy3 -m pip install --no-build-isolation -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -133,10 +133,10 @@ USER zenysis
 # NOTE: We can't easily create a venv in a seperate Docker stage, and then
 #       copy it here. Various links will be broken, and the venv will not
 #       work.
-RUN python3.9 -m pip install --upgrade pip \
+RUN python3.9 -m pip install pip=="24.1" \
     && python3.9 -m venv venv \
     && . venv/bin/activate \
-    && python -m pip install --upgrade pip
+    && python -m pip install pip=="24.1"
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
@@ -152,11 +152,11 @@ RUN . venv/bin/activate \
 # TODO: Investigate what it would take to have venv happen in a different
 #       build stage and copy it here. It would result in a leaner, cleaner
 #       image.
-RUN pypy3 -m pip install --upgrade pip setuptools \
+RUN pypy3 -m pip install pip=="24.1" \
     && pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
 RUN . venv_pypy3/bin/activate \
-    && pypy3 -m pip install --upgrade pip \
+    && pypy3 -m pip install pip=="24.1" \
     && pypy3 -m pip install -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -136,6 +136,8 @@ USER zenysis
 RUN python3.9 -m venv venv
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
+# wheel 0.43.0 HAS to be installed prior to installing requirments. If changing version here, also
+# change in requirements.txt.
 RUN . venv/bin/activate \
     && python -m pip install wheel==0.43.0 \
     && python -m pip install --no-build-isolation --verbose -r requirements.txt -r requirements-pipeline.txt
@@ -150,7 +152,8 @@ RUN . venv/bin/activate \
 #       image.
 RUN pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
-# pip-24.2
+# wheel 0.43.0 HAS to be installed prior to installing requirments. If changing version here, also
+# change in requirements.txt.
 RUN . venv_pypy3/bin/activate \
     && python -m pip install wheel==0.43.0 \
     && pypy -m pip install --no-build-isolation --verbose -r requirements.txt -r requirements-pipeline.txt

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -133,9 +133,9 @@ USER zenysis
 # NOTE: We can't easily create a venv in a seperate Docker stage, and then
 #       copy it here. Various links will be broken, and the venv will not
 #       work.
-RUN python3.9 -m pip install --upgrade pip setuptools \
+RUN python3.9 -m pip install --upgrade pip \
     && python3.9 -m venv venv \
-    && . venv/bin/activate && python -m pip install --upgrade pip setuptools
+    && . venv/bin/activate && python -m pip install --upgrade pip
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -135,11 +135,11 @@ USER zenysis
 #       work.
 RUN python3.9 -m venv venv \
     && . venv/bin/activate \
-    && python -m pip install --upgrade pip setuptools
+    && python -m pip install --upgrade pip
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
-    && python -m pip install -r requirements.txt -r requirements-pipeline.txt
+    && python -m pip install --no-build-isolation -r requirements.txt -r requirements-pipeline.txt
 
 # PyPy
 # Update setup and create venv.
@@ -152,8 +152,8 @@ RUN . venv/bin/activate \
 RUN pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
 RUN . venv_pypy3/bin/activate \
-    && pypy3 -m pip install --upgrade pip setuptools \
-    && pypy3 -m pip install -r requirements.txt -r requirements-pipeline.txt
+    && pypy3 -m pip install --upgrade pip \
+    && pypy3 -m pip install --no-build-isolation -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.
 COPY pipeline ./pipeline

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -140,7 +140,9 @@ RUN python3.9 -m pip install --upgrade pip \
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
-    && python -m pip install -r requirements.txt -r requirements-pipeline.txt
+    && python -m pip install -r requirements.txt
+RUN . venv/bin/activate \
+    && python -m pip install -r requirements-pipeline.txt
 
 # PyPy
 # Update setup and create venv.

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -137,6 +137,7 @@ RUN python3.9 -m venv venv
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
 RUN . venv/bin/activate \
+    && python -m pip install wheel==0.43.0 \
     && python -m pip install --no-build-isolation --verbose -r requirements.txt -r requirements-pipeline.txt
 
 # PyPy

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -138,8 +138,8 @@ RUN python3.9 -m venv venv \
     && python -m pip install --upgrade pip
 # Install dependencies.
 COPY requirements.txt requirements-pipeline.txt ./
+# && python -m pip install --upgrade pip \
 RUN . venv/bin/activate \
-    && python -m pip install --upgrade pip \
     && python -m pip install --no-build-isolation --verbose -r requirements.txt -r requirements-pipeline.txt
 
 # PyPy

--- a/docker/pipeline/Dockerfile
+++ b/docker/pipeline/Dockerfile
@@ -152,7 +152,8 @@ RUN pypy3 -m venv venv_pypy3
 # Install pypy dependencies.
 # pip-24.2
 RUN . venv_pypy3/bin/activate \
-    && pypy -m pip install --no-build-isolation -r requirements.txt -r requirements-pipeline.txt
+    && python -m pip install wheel==0.43.0 \
+    && pypy -m pip install --no-build-isolation --verbose -r requirements.txt -r requirements-pipeline.txt
 
 # Copy only what the pipeline needs.
 COPY pipeline ./pipeline

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,4 +1,4 @@
-setuptools=71.1.0
+setuptools==71.1.0
 xlrd>=1.0.0
 pyshp
 # shapely 2.0 requires numpy 1.19, which is higher than our pinned pypy version.

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,4 +1,3 @@
-setuptools==71.1.0
 xlrd>=1.0.0
 pyshp
 # shapely 2.0 requires numpy 1.19, which is higher than our pinned pypy version.

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,3 +1,4 @@
+setuptools=71.1.0
 xlrd>=1.0.0
 pyshp
 # shapely 2.0 requires numpy 1.19, which is higher than our pinned pypy version.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
 # It's still to be examined if all of these are really necessary there.
-setuptools=71.1.0
+setuptools==71.1.0
 celery==5.4.0
 Werkzeug==0.16.1
 MarkupSafe==0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
 # It's still to be examined if all of these are really necessary there.
-setuptools==71.1.0
+# setuptools=59.6.0
 celery==5.4.0
 Werkzeug==0.16.1
 MarkupSafe==0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 setuptools==71.1.0
 attrs==21.4.0
+wheel==0.43.0
+Cython<3.0.0
 # NOTE: these requirements were moved here from `requirements-web.txt`
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
@@ -25,7 +27,7 @@ ethiopian-date-converter==0.1.5
 hvac>=0.7.0
 pandas>=1.3,<2.0 ; platform_python_implementation != 'PyPy'
 psycopg2-binary==2.8.5 ; platform_python_implementation != 'PyPy' # use psycopg2 on mac with M1
-python-Levenshtein==0.12.0
+python-Levenshtein==0.12.1
 python-dateutil>=2.8.1
 requests==2.28.1 ; platform_python_implementation != 'PyPy'
 httpx[socks]==0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
 # It's still to be examined if all of these are really necessary there.
-setuptools==71.1.0
 celery==5.4.0
 Werkzeug==0.16.1
 MarkupSafe==0.23
@@ -38,7 +37,7 @@ retry>=0.9.2
 watchdog>=0.8.3
 pyyaml>=3.12
 boto3==1.16.25
-SQLAlchemy==1.3.3
+SQLAlchemy==1.3.24
 related>=0.7.0
 attrs==21.4.0
 gspread>=5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
 # It's still to be examined if all of these are really necessary there.
-# setuptools=59.6.0
+setuptools==59.6.0
 celery==5.4.0
 Werkzeug==0.16.1
 MarkupSafe==0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
 # It's still to be examined if all of these are really necessary there.
-setuptools==59.6.0
+setuptools=71.1.0
 celery==5.4.0
 Werkzeug==0.16.1
 MarkupSafe==0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools==71.1.0
+attrs==21.4.0
 # NOTE: these requirements were moved here from `requirements-web.txt`
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.
 # It's still to be examined if all of these are really necessary there.
+setuptools==71.1.0
 celery==5.4.0
 Werkzeug==0.16.1
 MarkupSafe==0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 setuptools==71.1.0
 attrs==21.4.0
 # Wheel 0.43.0 is duplicated in Dockerfile. If changing version here, also change in Dockerfile.
+# Take note that in some cases wheel needs to be installed prior to running pip install, so you
+# may find that running pip install twice will resolve relating to bdist_wheel being missing.
 wheel==0.43.0
 Cython<3.0.0
 # NOTE: these requirements were moved here from `requirements-web.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==71.1.0
 # NOTE: these requirements were moved here from `requirements-web.txt`
 # so requirements reflect the actual state of what is installed at pipeline machines,
 # for some reason they don't correspond to the requirements state.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 setuptools==71.1.0
 attrs==21.4.0
+# Wheel 0.43.0 is duplicated in Dockerfile. If changing version here, also change in Dockerfile.
 wheel==0.43.0
 Cython<3.0.0
 # NOTE: these requirements were moved here from `requirements-web.txt`


### PR DESCRIPTION
**Summary:**
Setuptools has deprecated setup.py test : https://setuptools.pypa.io/en/stable/history.html#v72-0-0
`setuptools.command.test` is used by SQLAlchemy-1.3.3, resulting in error: `ModuleNotFoundError: No module named 'setuptools.command.test'` during pipeline build.
Upgrading SQLAlchemy-1.3.3 won't be done on this revision of Harmony, so we need to pin setuptools to a version that works.

Setuptools runs in isolation when building wheels, and will pull down latest setuptools (at this point v72.0.0), so we have to add `--no-build-isolation` to pip install.

Adding `--no-build-isolation` will fail unless some additional dependencies are pulled in (attrs, wheel and Cython)

**Other**

0.12.0 version of `python-Levenshtein` was yanked, so upgraded to 0.12.1
SQLAlchemy upgraded from `1.3.3` to `1.3.24` - `1.3.20` and upwards install faster because they have pre-built wheels. .4 to .24 seem to all be bug fixes.

**Test Plan:**
Build image in GitHub actions.