### PR TITLE
Allow override of pipeline image prefix

### DIFF
--- a/docker-compose.pipeline.yaml
+++ b/docker-compose.pipeline.yaml
@@ -1,7 +1,7 @@
 services:
   etl-pipeline:
     platform: linux/amd64
-    image: ${DOCKER_NAMESPACE:-ghcr.io/zenysis}/harmony-etl-pipeline:${DOCKER_TAG:-latest}
+    image: ${DOCKER_NAMESPACE:-ghcr.io/zenysis}/${DOCKER_IMAGE_PREFIX:-harmony}-etl-pipeline:${DOCKER_TAG:-latest}
     volumes:
       - ${DRUID_SHARED_FOLDER:-/home/share}:/home/share
       - ${OUTPUT_PATH:-/data/output}:/zenysis/pipeline/out


### PR DESCRIPTION
We need to be able to easily override the image prefix to pull non-default pipeline images from Harmony forks.

