### PR TITLE
building only on approval saves us some cpu - do not merge

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,26 +14,32 @@ jobs:
     what:
         runs-on: ubuntu-latest
         steps:
-          - name: Get the PR associated with the branch
-            id: get_pr
-            uses: octokit/request-action@v2.x
-            with:
-              route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
-              mediaType: '{"format": "json"}'
-          - name: Check if PR exists
+          - name: Thing
             run: |
-              if [ -z "${{ steps.get_pr.outputs.data }}" ]; then
-                echo "No PR found for this branch."
-                exit 0
-              fi
-          - name: Get review status
-            id: get_reviews
-            uses: octokit/request-action@v2.x
-            with:
-              route: GET /repos/${{ github.repository }}/pulls/${{ steps.get_pr.outputs.data[0].number }}/reviews
-          - name: Output reviews
-            run: |
-              echo "Reviews: ${{ steps.get_reviews.outputs.data }}"
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/${{ github.repository_owner }}/${{ github.repository}}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+          # - name: Get the PR associated with the branch
+          #   id: get_pr
+          #   uses: octokit/request-action@v2.x
+          #   with:
+          #     route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+          #     mediaType: '{"format": "json"}'
+          # - name: Check if PR exists
+          #   run: |
+          #     if [ -z "${{ steps.get_pr.outputs.data }}" ]; then
+          #       echo "No PR found for this branch."
+          #       exit 0
+          #     fi
+          # - name: Get review status
+          #   id: get_reviews
+          #   uses: octokit/request-action@v2.x
+          #   with:
+          #     route: GET /repos/${{ github.repository }}/pulls/${{ steps.get_pr.outputs.data[0].number }}/reviews
+          # - name: Output reviews
+          #   run: |
+          #     echo "Reviews: ${{ steps.get_reviews.outputs.data }}"
     prepare:
         if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,6 +8,7 @@ on:
     push:
       branches:
         - main
+    pull_request_review:
     pull_request:
 
 jobs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,6 +12,11 @@ on:
     pull_request:
 
 jobs:
+    what:
+        runs-on: ubuntu-latest
+        steps:
+          - name: something
+            run: echo ${{github.event.review.state}}
     prepare:
         if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,9 +8,12 @@ on:
     push:
       branches:
         - main
+    pull_request_review:
+      types: [submitted]
 
 jobs:
     prepare:
+        if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         steps:
             - id: repository_name
@@ -21,6 +24,7 @@ jobs:
             lowercase_repo_name: ${{ steps.repository_name.outputs.lowercase_repo_name }}
 
     build-etl-pipeline:
+        if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         needs: prepare
         steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,8 +8,7 @@ on:
     push:
       branches:
         - main
-    pull_request_review:
-      types: [submitted]
+    pull_request:
 
 jobs:
     prepare:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,33 +13,35 @@ on:
 jobs:
     what:
         runs-on: ubuntu-latest
+        env:
+          GH_TOKEN: ${{ github.token }}
         steps:
-          - name: Thing
+          # - name: Thing
+          #   run: |
+          #     gh api \
+          #       -H "Accept: application/vnd.github+json" \
+          #       -H "X-GitHub-Api-Version: 2022-11-28" \
+          #       /repos/${{ github.repository_owner }}/${{ github.repository}}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+          - name: Get the PR associated with the branch
+            id: get_pr
+            uses: octokit/request-action@v2.x
+            with:
+              route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+              mediaType: '{"format": "json"}'
+          - name: Check if PR exists
             run: |
-              gh api \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                /repos/${{ github.repository_owner }}/${{ github.repository}}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
-          # - name: Get the PR associated with the branch
-          #   id: get_pr
-          #   uses: octokit/request-action@v2.x
-          #   with:
-          #     route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
-          #     mediaType: '{"format": "json"}'
-          # - name: Check if PR exists
-          #   run: |
-          #     if [ -z "${{ steps.get_pr.outputs.data }}" ]; then
-          #       echo "No PR found for this branch."
-          #       exit 0
-          #     fi
-          # - name: Get review status
-          #   id: get_reviews
-          #   uses: octokit/request-action@v2.x
-          #   with:
-          #     route: GET /repos/${{ github.repository }}/pulls/${{ steps.get_pr.outputs.data[0].number }}/reviews
-          # - name: Output reviews
-          #   run: |
-          #     echo "Reviews: ${{ steps.get_reviews.outputs.data }}"
+              if [ -z "${{ steps.get_pr.outputs.data }}" ]; then
+                echo "No PR found for this branch."
+                exit 0
+              fi
+          - name: Get review status
+            id: get_reviews
+            uses: octokit/request-action@v2.x
+            with:
+              route: GET /repos/${{ github.repository }}/pulls/${{ steps.get_pr.outputs.data[0].number }}/reviews
+          - name: Output reviews
+            run: |
+              echo "Reviews: ${{ steps.get_reviews.outputs.data }}"
     prepare:
         if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,5 +37,7 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline
               run: |
+                echo "github.head_ref : ${{ github.head_ref }}"
+                echo "github.ref_name : ${{ github.ref_name }}"
                 docker build --platform linux/amd64 -t ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} -f docker/pipeline/Dockerfile --cache-from ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:main,ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
                 docker push ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,7 +22,7 @@ jobs:
               gh api \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                /repos/${{ github.repository_owner }}/${{ github.repository}}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+                /repos/${{ github.repository}}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
           # - name: Get the PR associated with the branch
           #   id: get_pr
           #   uses: octokit/request-action@v2.x

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,15 +8,32 @@ on:
     push:
       branches:
         - main
-    pull_request_review:
     pull_request:
 
 jobs:
     what:
         runs-on: ubuntu-latest
         steps:
-          - name: something
-            run: echo ${{github.event.review.state}}
+          - name: Get the PR associated with the branch
+            id: get_pr
+            uses: octokit/request-action@v2.x
+            with:
+              route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+              mediaType: '{"format": "json"}'
+          - name: Check if PR exists
+            run: |
+              if [ -z "${{ steps.get_pr.outputs.data }}" ]; then
+                echo "No PR found for this branch."
+                exit 0
+              fi
+          - name: Get review status
+            id: get_reviews
+            uses: octokit/request-action@v2.x
+            with:
+              route: GET /repos/${{ github.repository }}/pulls/${{ steps.get_pr.outputs.data[0].number }}/reviews
+          - name: Output reviews
+            run: |
+              echo "Reviews: ${{ steps.get_reviews.outputs.data }}"
     prepare:
         if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,32 +17,32 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         steps:
-          # - name: Thing
+          - name: Thing
+            run: |
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/${{ github.repository_owner }}/${{ github.repository}}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+          # - name: Get the PR associated with the branch
+          #   id: get_pr
+          #   uses: octokit/request-action@v2.x
+          #   with:
+          #     route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
+          #     mediaType: '{"format": "json"}'
+          # - name: Check if PR exists
           #   run: |
-          #     gh api \
-          #       -H "Accept: application/vnd.github+json" \
-          #       -H "X-GitHub-Api-Version: 2022-11-28" \
-          #       /repos/${{ github.repository_owner }}/${{ github.repository}}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
-          - name: Get the PR associated with the branch
-            id: get_pr
-            uses: octokit/request-action@v2.x
-            with:
-              route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref }}
-              mediaType: '{"format": "json"}'
-          - name: Check if PR exists
-            run: |
-              if [ -z "${{ steps.get_pr.outputs.data }}" ]; then
-                echo "No PR found for this branch."
-                exit 0
-              fi
-          - name: Get review status
-            id: get_reviews
-            uses: octokit/request-action@v2.x
-            with:
-              route: GET /repos/${{ github.repository }}/pulls/${{ steps.get_pr.outputs.data[0].number }}/reviews
-          - name: Output reviews
-            run: |
-              echo "Reviews: ${{ steps.get_reviews.outputs.data }}"
+          #     if [ -z "${{ steps.get_pr.outputs.data }}" ]; then
+          #       echo "No PR found for this branch."
+          #       exit 0
+          #     fi
+          # - name: Get review status
+          #   id: get_reviews
+          #   uses: octokit/request-action@v2.x
+          #   with:
+          #     route: GET /repos/${{ github.repository }}/pulls/${{ steps.get_pr.outputs.data[0].number }}/reviews
+          # - name: Output reviews
+          #   run: |
+          #     echo "Reviews: ${{ steps.get_reviews.outputs.data }}"
     prepare:
         if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,6 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         steps:
           # - name: Thing
           #   run: |

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,9 +8,12 @@ on:
     push:
       branches:
         - main
+    pull_request_review:
+      types: [submitted]
 
 jobs:
     prepare:
+        if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         steps:
             - id: repository_name
@@ -21,6 +24,7 @@ jobs:
             lowercase_repo_name: ${{ steps.repository_name.outputs.lowercase_repo_name }}
 
     build-web-client:
+        if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         needs: prepare
         steps:
@@ -36,6 +40,7 @@ jobs:
                 docker build --platform linux/amd64 -t ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-client --cache-from ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:main,ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
                 docker push ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }}
     build-web-server:
+        if: github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         needs: prepare
         steps:
@@ -51,6 +56,7 @@ jobs:
                 docker build --platform linux/amd64 -t ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-server --cache-from ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:main,ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
                 docker push ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }}
     build-web-image:
+        if: github.event.review.state == 'approved'
         needs: [prepare, build-web-client, build-web-server]
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
Ideally images are buildable before merging - but building on every commit to a PR is too expensive.

What we do now, is wait until a PR is approved before building it.

This way branch rules can be kept in place (must be built before merging) and don't waste cycles building on each commit.

