### PR TITLE
limit docker log size

### DIFF
--- a/druid_setup/cluster/docker-compose-data.yml
+++ b/druid_setup/cluster/docker-compose-data.yml
@@ -18,6 +18,12 @@
 #
 version: "2.2"
 
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "10"
+
 volumes:
   zen_extensions: {}
   middle_var: {}
@@ -31,6 +37,7 @@ services:
       - zen_extensions:/druid/extensions
     environment:
       - ZEN_DRUID_VERSION=${DRUID_VERSION}
+    logging: *default-logging
 
   historical:
     image: apache/druid:${DRUID_VERSION}
@@ -53,6 +60,7 @@ services:
     environment:
       - druid_host=${DRUID_DATA_HOST}
       - druid_zk_service_host=${DRUID_ZOOKEEPER_HOST}
+    logging: *default-logging
 
   middlemanager:
     image: apache/druid:${DRUID_VERSION}
@@ -75,3 +83,4 @@ services:
       - environment/middlemanager.env
     environment:
       - druid_zk_service_host=${DRUID_ZOOKEEPER_HOST}
+    logging: *default-logging

--- a/druid_setup/cluster/docker-compose-master.yml
+++ b/druid_setup/cluster/docker-compose-master.yml
@@ -18,6 +18,12 @@
 #
 version: "2.2"
 
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "10"
+
 volumes:
   zen_extensions: {}
   metadata_data: {}
@@ -43,6 +49,7 @@ services:
       - zen_extensions:/druid/extensions
     environment:
       - ZEN_DRUID_VERSION=${DRUID_VERSION}
+    logging: *default-logging
 
   postgres:
     container_name: postgres
@@ -56,6 +63,7 @@ services:
       - POSTGRES_PASSWORD=${DRUID_POSTGRES_PASSWORD}
       - POSTGRES_USER=${DRUID_POSTGRES_USER}
       - POSTGRES_DB=${DRUID_POSTGRES_DB}
+    logging: *default-logging
 
   memcache:
     container_name: memcache
@@ -63,6 +71,7 @@ services:
     restart: always
     ports:
       - "11211:11211"
+    logging: *default-logging
 
   # Need 3.5 or later for container nodes
   zookeeper:
@@ -76,6 +85,7 @@ services:
       - zookeeper_datalog:/datalog
     environment:
       - ZOO_MY_ID=1
+    logging: *default-logging
 
   coordinator:
     image: apache/druid:${DRUID_VERSION}
@@ -102,3 +112,4 @@ services:
       - druid_metadata_storage_connector_connectURI=jdbc:postgresql://${DRUID_POSTGRES_HOST}:5432/${DRUID_POSTGRES_DB}
       - druid_metadata_storage_connector_user=${DRUID_POSTGRES_USER}
       - druid_metadata_storage_connector_password=${DRUID_POSTGRES_PASSWORD}
+    logging: *default-logging

--- a/druid_setup/cluster/docker-compose-query.yml
+++ b/druid_setup/cluster/docker-compose-query.yml
@@ -18,6 +18,12 @@
 #
 version: "2.2"
 
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "10"
+
 volumes:
   zen_extensions: {}
   broker_var: {}
@@ -31,6 +37,7 @@ services:
       - zen_extensions:/druid/extensions
     environment:
       - ZEN_DRUID_VERSION=${DRUID_VERSION}
+    logging: *default-logging
 
   broker:
     image: apache/druid:${DRUID_VERSION}
@@ -50,6 +57,7 @@ services:
       - environment/broker.env
     environment:
       - druid_zk_service_host=${DRUID_ZOOKEEPER_HOST}
+    logging: *default-logging
 
   router:
     image: apache/druid:${DRUID_VERSION}
@@ -68,3 +76,4 @@ services:
       - environment/common.env
     environment:
       - druid_zk_service_host=${DRUID_ZOOKEEPER_HOST}
+    logging: *default-logging

--- a/druid_setup/single/docker-compose.yml
+++ b/druid_setup/single/docker-compose.yml
@@ -30,6 +30,12 @@ volumes:
   coordinator_var: {}
   router_var: {}
 
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "10"
+
 services:
   extension_loader:
     build:
@@ -38,6 +44,7 @@ services:
       - zen_extensions:/druid/extensions
     environment:
       - ZEN_DRUID_VERSION=${DRUID_VERSION}
+    logging: *default-logging
 
   postgres:
     image: postgres:latest
@@ -52,6 +59,7 @@ services:
       - POSTGRES_PASSWORD=FoolishPassword
       - POSTGRES_USER=druid
       - POSTGRES_DB=druid
+    logging: *default-logging
 
   memcache:
     container_name: memcache
@@ -59,6 +67,7 @@ services:
     restart: always
     ports:
       - "11211:11211"
+    logging: *default-logging
 
   # Need 3.5 or later for container nodes
   zookeeper:
@@ -73,6 +82,7 @@ services:
       - zookeeper_logs:/logs
     environment:
       - ZOO_MY_ID=1
+    logging: *default-logging
 
   coordinator:
     platform: linux/amd64
@@ -94,6 +104,7 @@ services:
     env_file:
       - environment/common.env
       - environment/coordinator.env
+    logging: *default-logging
 
   broker:
     platform: linux/amd64
@@ -116,6 +127,7 @@ services:
     env_file:
       - environment/common.env
       - environment/broker.env
+    logging: *default-logging
 
   historical:
     platform: linux/amd64
@@ -140,6 +152,7 @@ services:
     env_file:
       - environment/common.env
       - environment/historical.env
+    logging: *default-logging
 
   middlemanager:
     platform: linux/amd64
@@ -164,6 +177,7 @@ services:
     env_file:
       - environment/common.env
       - environment/middlemanager.env
+    logging: *default-logging
 
   router:
     platform: linux/amd64
@@ -185,3 +199,4 @@ services:
     env_file:
       - environment/common.env
       - environment/router.env
+    logging: *default-logging


### PR DESCRIPTION


A chatty container (like druid) can quickly use up all available disk space if log sizes aren't limited.