### PR TITLE
Being able to easily override the pull policy is a good idea

### DIFF
--- a/docker-compose.pipeline.yaml
+++ b/docker-compose.pipeline.yaml
@@ -2,7 +2,7 @@ services:
   etl-pipeline:
     platform: linux/amd64
     image: ${DOCKER_NAMESPACE:-ghcr.io/zenysis}/${DOCKER_IMAGE_PREFIX:-harmony}-etl-pipeline:${DOCKER_TAG:-latest}
-    pull_policy: always
+    pull_policy: ${PULL_POLICY:-always}
     volumes:
       - ${DRUID_SHARED_FOLDER:-/home/share}:/home/share
       - ${OUTPUT_PATH:-/data/output}:/zenysis/pipeline/out


### PR DESCRIPTION
Being able to override the pull policy for pipelines can be very useful.

If you're setting up a cronjob on a server, and you don't want to leave a image repository token lying around on that server, then you can pull the image locally one time, and then switch to using the locally cached image.