### PR TITLE
images need to be pushed to the appropriate repo owner packages

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,7 +19,7 @@ jobs:
                 echo "lowercase_repo_name=${lowercase_repo_name}" >> $GITHUB_OUTPUT
             - id: repository_owner
               run: |
-                lowercase_repo_owner=$(echo "${{ github.event.repository.owner }}" | tr '[:upper:]' '[:lower:]')
+                lowercase_repo_owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
                 echo "lowercase_repo_owner=${lowercase_repo_owner}" >> $GITHUB_OUTPUT
         outputs:
             lowercase_repo_name: ${{ steps.repository_name.outputs.lowercase_repo_name }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,5 +33,5 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} -f docker/pipeline/Dockerfile --cache-from ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:main,ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} -f docker/pipeline/Dockerfile --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,8 +17,13 @@ jobs:
               run: |
                 lowercase_repo_name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
                 echo "lowercase_repo_name=${lowercase_repo_name}" >> $GITHUB_OUTPUT
+            - id: repository_owner
+              run: |
+                lowercase_repo_owner=$(echo "${{ github.event.repository.owner }}" | tr '[:upper:]' '[:lower:]')
+                echo "lowercase_repo_owner=${lowercase_repo_owner}" >> $GITHUB_OUTPUT
         outputs:
             lowercase_repo_name: ${{ steps.repository_name.outputs.lowercase_repo_name }}
+            lowercase_repo_owner: ${{ steps.repository_owner.outputs.lowercase_repo_owner }}
 
     build-etl-pipeline:
         runs-on: ubuntu-latest
@@ -33,5 +38,5 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} -f docker/pipeline/Dockerfile --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} -f docker/pipeline/Dockerfile --cache-from ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:main,ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-etl-pipeline:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,8 +19,8 @@ jobs:
                 echo "lowercase_repo_name=${lowercase_repo_name}" >> $GITHUB_OUTPUT
             - id: repository_owner
               run: |
-                echo ${{ github.event.repository.owner }}
-                lowercase_repo_owner=$(echo "${{ github.event.repository.owner }}" | tr '[:upper:]' '[:lower:]')
+                echo ${{ github.event.repository.owner.name }}
+                lowercase_repo_owner=$(echo "${{ github.event.repository.owner.name }}" | tr '[:upper:]' '[:lower:]')
                 echo "lowercase_repo_owner=${lowercase_repo_owner}" >> $GITHUB_OUTPUT
         outputs:
             lowercase_repo_name: ${{ steps.repository_name.outputs.lowercase_repo_name }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,7 +19,8 @@ jobs:
                 echo "lowercase_repo_name=${lowercase_repo_name}" >> $GITHUB_OUTPUT
             - id: repository_owner
               run: |
-                echo ${{ github.event.repository.owner.name }}
+                echo github.event.repository.owner.name: ${{ github.event.repository.owner.name }}
+                echo : github.repository_owner : ${{ github.repository_owner }}
                 lowercase_repo_owner=$(echo "${{ github.event.repository.owner.name }}" | tr '[:upper:]' '[:lower:]')
                 echo "lowercase_repo_owner=${lowercase_repo_owner}" >> $GITHUB_OUTPUT
         outputs:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -17,8 +17,13 @@ jobs:
               run: |
                 lowercase_repo_name=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
                 echo "lowercase_repo_name=${lowercase_repo_name}" >> $GITHUB_OUTPUT
+            - id: repository_owner
+              run: |
+                lowercase_repo_owner=$(echo "${{ github.event.repository.owner }}" | tr '[:upper:]' '[:lower:]')
+                echo "lowercase_repo_owner=${lowercase_repo_owner}" >> $GITHUB_OUTPUT
         outputs:
             lowercase_repo_name: ${{ steps.repository_name.outputs.lowercase_repo_name }}
+            lowercase_repo_owner: ${{ steps.repository_owner.outputs.lowercase_repo_owner }}
 
     build-web-client:
         runs-on: ubuntu-latest
@@ -33,8 +38,8 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-web-client
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-client --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-client --cache-from ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:main,ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }}
     build-web-server:
         runs-on: ubuntu-latest
         needs: prepare
@@ -48,8 +53,8 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-web-server
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-server --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-server --cache-from ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:main,ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }}
     build-web-image:
         needs: [prepare, build-web-client, build-web-server]
         runs-on: ubuntu-latest
@@ -63,5 +68,5 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-web-image
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web --build-arg NAMESPACE=ghcr.io/${{ github.repository_owner }} --build-arg IMAGE_PREFIX=${{ needs.prepare.outputs.lowercase_repo_name }} --build-arg TAG=${{ github.head_ref || github.ref_name }} --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web --build-arg NAMESPACE=ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }} --build-arg IMAGE_PREFIX=${{ needs.prepare.outputs.lowercase_repo_name }} --build-arg TAG=${{ github.head_ref || github.ref_name }} --cache-from ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:main,ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ needs.prepare.outputs.lowercase_repo_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -33,8 +33,8 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-web-client
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-client --cache-from ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:main,ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-client --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-client:${{ github.head_ref || github.ref_name }}
     build-web-server:
         runs-on: ubuntu-latest
         needs: prepare
@@ -48,8 +48,8 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-web-server
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-server --cache-from ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:main,ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web-server --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web-server:${{ github.head_ref || github.ref_name }}
     build-web-image:
         needs: [prepare, build-web-client, build-web-server]
         runs-on: ubuntu-latest
@@ -63,5 +63,5 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build ${{ needs.prepare.outputs.lowercase_repo_name }}-web-image
               run: |
-                docker build --platform linux/amd64 -t ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web --build-arg NAMESPACE=ghcr.io/zenysis --build-arg IMAGE_PREFIX=${{ needs.prepare.outputs.lowercase_repo_name }} --build-arg TAG=${{ github.head_ref || github.ref_name }} --cache-from ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web:main,ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
-                docker push ghcr.io/zenysis/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }}
+                docker build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} -f docker/web/Dockerfile_web --build-arg NAMESPACE=ghcr.io/${{ github.repository_owner }} --build-arg IMAGE_PREFIX=${{ needs.prepare.outputs.lowercase_repo_name }} --build-arg TAG=${{ github.head_ref || github.ref_name }} --cache-from ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:main,ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }} --build-arg BUILDKIT_INLINE_CACHE=1 .
+                docker push ghcr.io/${{ github.repository_owner }}/${{ needs.prepare.outputs.lowercase_repo_name }}-web:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,6 +19,7 @@ jobs:
                 echo "lowercase_repo_name=${lowercase_repo_name}" >> $GITHUB_OUTPUT
             - id: repository_owner
               run: |
+                echo ${{ github.event.repository.owner }}
                 lowercase_repo_owner=$(echo "${{ github.event.repository.owner }}" | tr '[:upper:]' '[:lower:]')
                 echo "lowercase_repo_owner=${lowercase_repo_owner}" >> $GITHUB_OUTPUT
         outputs:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,9 +19,7 @@ jobs:
                 echo "lowercase_repo_name=${lowercase_repo_name}" >> $GITHUB_OUTPUT
             - id: repository_owner
               run: |
-                echo github.event.repository.owner.name: ${{ github.event.repository.owner.name }}
-                echo : github.repository_owner : ${{ github.repository_owner }}
-                lowercase_repo_owner=$(echo "${{ github.event.repository.owner.name }}" | tr '[:upper:]' '[:lower:]')
+                lowercase_repo_owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
                 echo "lowercase_repo_owner=${lowercase_repo_owner}" >> $GITHUB_OUTPUT
         outputs:
             lowercase_repo_name: ${{ steps.repository_name.outputs.lowercase_repo_name }}


### PR DESCRIPTION
With a repo hosted by a different organization, we expect images to be pushed to the corresponding packages.

So, hard coded `zenysis` has to change to `${{ github.repository_owner }}`