### PR TITLE
37.0.2 has a vulnerability, upgrading to latest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Paramiko deps (used by Fabric)
-cryptography==37.0.2
+cryptography==44.0.0
 pyasn1==0.4.8
 PyNaCl==1.4.0
 


### PR DESCRIPTION
This should not be a concern, as it is used by internal tools, but it's a quick and easy update to do.

