### PR TITLE
Remove reference to file that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,6 @@ When you run a script or the web server, select a configuration by setting the `
       export ZEN_ENV='usa'
       ```
 
-### A note on Makefiles
-
-See [Makefiles.md](Makefiles.md) for more information on the Makefiles in this repository.
-
 ## Local development setup
 
 In order to run a local web server or run data pipeline steps on the command line, you'll need to set up a local development environment. This is distinct from setting up production servers (explained in other sections).


### PR DESCRIPTION
**Summary:**

As per https://github.com/Zenysis/Harmony/issues/144 - there is no Makefiles.md checked into the project, it's contents were moved to https://github.com/Zenysis/Harmony/wiki/Makefiles

Instead of updating the reference - I'll just remove it entirely - so there's no burden re. updating links.


